### PR TITLE
use config method to setup logger

### DIFF
--- a/src/client.v
+++ b/src/client.v
@@ -59,12 +59,12 @@ pub:
 	write_timeout   ?time.Duration
 }
 
-fn (config BotConfig) get_level() log.Level {
-	return if config.debug {
-		.debug
-	} else {
-		.info
+fn (config BotConfig) setup_logger() log.Log {
+	mut l := log.Log{
+		output_label: 'discord.v'
 	}
+	l.set_level(if config.debug { .debug } else { .info })
+	return l
 }
 
 // `bot` creates a new [GatewayClient] that can be used to listen events.
@@ -76,10 +76,7 @@ pub fn bot(token string, config BotConfig) GatewayClient {
 		cache: config.cache
 		intents: int(config.intents)
 		large_threshold: config.large_threshold
-		logger: log.Log{
-			level: config.get_level()
-			output_label: 'discord.v'
-		}
+		logger: config.setup_logger()
 		presence: config.presence
 		properties: config.properties
 		read_timeout: config.read_timeout


### PR DESCRIPTION
The main change is that it won't initialize a private struct field but use the related log method to set the log level. It looks good on the `pub fn bot` function as well 😊

Required for https://github.com/vlang/v/pull/21183