### PR TITLE
update deprecated

### DIFF
--- a/src/cdn_test.v
+++ b/src/cdn_test.v
@@ -16,8 +16,8 @@ fn test_cdn_attachment() {
 	attachment := CDNAttachment.parse(sample) or {
 		panic('CDNAttachment.parse should not return error on sample: ${err}')
 	}
-	assert attachment.expires_on.unix == 1708721118
-	assert attachment.issued_at.unix == 1707511518
+	assert attachment.expires_on.unix() == 1708721118
+	assert attachment.issued_at.unix() == 1707511518
 	assert attachment.unique_signature.len == 32
 	assert attachment.unique_signature == [u8(0x24), 0x81, 0xf3, 0x0d, 0xd6, 0x7f, 0x50, 0x3f,
 		0x54, 0xd0, 0x20, 0xae, 0x3b, 0x55, 0x33, 0xb9, 0x98, 0x7f, 0xae, 0x4e, 0x55, 0xf2, 0xb4,

--- a/src/client.v
+++ b/src/client.v
@@ -60,10 +60,9 @@ pub:
 }
 
 fn (config BotConfig) setup_logger() log.Log {
-	mut l := log.Log{
-		output_label: 'discord.v'
-	}
+	mut l := log.Log{}
 	l.set_level(if config.debug { .debug } else { .info })
+	l.set_output_label('discord.v')
 	return l
 }
 

--- a/src/gateway.v
+++ b/src/gateway.v
@@ -737,7 +737,7 @@ pub:
 pub fn (params UpdatePresenceParams) build() json2.Any {
 	return {
 		'since':      if since := params.since {
-			json2.Any(since.unix_time_milli())
+			json2.Any(since.unix_milli())
 		} else {
 			json2.null
 		}

--- a/src/http_test.v
+++ b/src/http_test.v
@@ -46,7 +46,7 @@ fn test_applications() {
 	application := rest.fetch_my_application() or { panic(err) }
 	assert rest.list_skus(application.id) or { panic(err) } == []
 
-	current_time := time.now().unix.str()
+	current_time := time.now().unix().str()
 	assert rest.edit_my_application(description: current_time) or { panic(err) }.description == current_time
 }
 

--- a/src/sentinels.v
+++ b/src/sentinels.v
@@ -5,9 +5,7 @@ import time
 
 // ASCII-encoded 'darp'
 pub const sentinel_int = 1886544228
-pub const sentinel_time = time.Time{
-	unix: 0
-}
+pub const sentinel_time = time.unix(0)
 
 // Compare using `target.str == sentinel_string.str`
 pub const sentinel_string = 'darp'

--- a/src/snowflake.v
+++ b/src/snowflake.v
@@ -17,7 +17,7 @@ pub fn (s Snowflake) timestamp() time.Time {
 }
 
 pub fn Snowflake.from(t time.Time) Snowflake {
-	return u64(t.unix_time_milli() - discord.snowflake_epoch) << 22
+	return u64(t.unix_milli() - discord.snowflake_epoch) << 22
 }
 
 pub fn Snowflake.now() Snowflake {


### PR DESCRIPTION
The PR makes some simple changes based on the recent development of V to ensure seamless compatibility with latest and future V.

1. Is setting of the output label that I forgot in the last PR
2. Is related to recently updated unix time handling